### PR TITLE
Fixed a typo where the index of CRT parameters were off by one

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,9 +122,9 @@ m = c1 ** 3 % n1
 m = c2 ** 3 % n2
 
 # Here's how this is done thanks to the CRT:
-M =  c0 * (n2*n3) * [(n2*n3) ** −1] % n0
-   + c1 * (n1*n3) * [(n1*n3) ** −1] % n1
-   + c2 * (n1*n2) * [(n1*n2) ** −1] % n2
+M =  c0 * (n1*n2) * [(n1*n2) ** −1] % n0
+   + c1 * (n0*n2) * [(n0*n2) ** −1] % n1
+   + c2 * (n0*n1) * [(n0*n1) ** −1] % n2
 
 # with [x ** -1] % n the multiplicative inverse of x modulo n
 # use gmpy.invert(x,n) for this calculation in python


### PR DESCRIPTION
Hi, I think you got the indices confused in the explanation of the Chinese Remainder Theorem. Here is how to fix it.

Thank you for this repo, btw, it pointed me in the right direction in a CTF and allowed me to get the flag!